### PR TITLE
chore: disable sourcemaps in Vite and TypeScript configurations

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -36,7 +36,7 @@ export default defineConfig({
   build: {
     outDir: 'Portfolio',
     emptyOutDir: true,
-    sourcemap: true,
+    sourcemap: false,
     minify: true,
     ssrManifest: true,
     modulePreload: true,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -14,9 +14,9 @@
       // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
       /* Emit */
       "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-      "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+      "declarationMap": false,                           /* Create sourcemaps for d.ts files. */
       // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-      "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */                                 /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+      "sourceMap": false,                                /* Create source map files for emitted JavaScript files. */                                 /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
       "outDir": "./Portfolio",                                   /* Specify an output folder for all emitted files. */
       "removeComments": true,                           /* Disable emitting comments. */
       "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */


### PR DESCRIPTION
This pull request involves changes to the configuration files for both the client and server to disable source maps. These changes are aimed at optimizing the build process by reducing the overhead associated with generating source maps.

### Changes to client configuration:

* [`client/vite.config.js`](diffhunk://#diff-7ad6f79fccbedd1cba943a6c1cf8742b0868e249f2393a52a47b6f78e13711f5L39-R39): Disabled source maps by setting `sourcemap` to `false` in the build configuration.

### Changes to server configuration:

* [`server/tsconfig.json`](diffhunk://#diff-f3eab147f9c67d8aeb9f4f641a6b199d8b9eebae738083ea2f9a4a79aaca0175L17-R19): Disabled source maps for both `.d.ts` files and emitted JavaScript files by setting `declarationMap` and `sourceMap` to `false`.