### PR TITLE
feat: Add robots.txt and sitemap generation functionality

### DIFF
--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,0 +1,21 @@
+import { MetadataRoute } from 'next';
+
+/**
+ * Generate robots.txt file
+ * @returns Robots.txt configuration
+ */
+export default function robots(): MetadataRoute.Robots {
+  // Get domain dynamically from environment or default to localhost
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` :
+    'http://ankan.site';
+
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,0 +1,38 @@
+import { MetadataRoute } from 'next';
+
+/**
+ * Generate a sitemap for the website
+ * @returns Sitemap configuration
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  // Get domain dynamically from environment or default to localhost
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` :
+    'http://ankan.site';
+
+  // Current date
+  const currentDate = new Date().toISOString();
+
+  // Define routes
+  // You can add more routes as needed
+  return [
+    {
+      url: `${baseUrl}`,
+      lastModified: currentDate,
+      changeFrequency: 'weekly' as const,
+      priority: 1.0,
+    },
+    {
+      url: `${baseUrl}/about`,
+      lastModified: currentDate,
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/contact`,
+      lastModified: currentDate,
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    },
+  ];
+}


### PR DESCRIPTION
This pull request adds dynamic generation of `robots.txt` and `sitemap.xml` files to the frontend, improving SEO and crawler management. Both files use the deployment environment to determine the base URL, ensuring correct URLs in different environments.

SEO and crawler configuration:

* Added `frontend/app/robots.ts` to generate a `robots.txt` file dynamically, specifying allowed and disallowed paths and referencing the sitemap, with the base URL determined from environment variables.
* Added `frontend/app/sitemap.ts` to generate a `sitemap.xml` file dynamically, including main site routes with metadata such as last modified date, change frequency, and priority, also using a dynamic base URL.