### PR TITLE
fix: Simplify base URL assignment in robots.txt and sitemap generation

### DIFF
--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -6,9 +6,7 @@ import { MetadataRoute } from 'next';
  */
 export default function robots(): MetadataRoute.Robots {
   // Get domain dynamically from environment or default to localhost
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ||
-    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` :
-    'http://ankan.site';
+  const baseUrl = 'http://ankan.site';
 
   return {
     rules: {

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -6,9 +6,7 @@ import { MetadataRoute } from 'next';
  */
 export default function sitemap(): MetadataRoute.Sitemap {
   // Get domain dynamically from environment or default to localhost
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ||
-    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` :
-    'http://ankan.site';
+  const baseUrl = 'http://ankan.site';
 
   // Current date
   const currentDate = new Date().toISOString();


### PR DESCRIPTION
This pull request makes a small but important change to how the `baseUrl` is set in both the `robots.ts` and `sitemap.ts` files. Instead of dynamically determining the domain from environment variables, the `baseUrl` is now hardcoded to `'http://ankan.site'`. This simplifies the configuration but removes environment-based flexibility.

- Hardcoded the `baseUrl` to `'http://ankan.site'` in both `frontend/app/robots.ts` [[1]](diffhunk://#diff-529628bc9eecdd7f290c32db24832aa4e64a6adab6dbd02286cd550a7241c1f8L9-R9) and `frontend/app/sitemap.ts` [[2]](diffhunk://#diff-6aba68df4b2f30b05f40df85caaca72e170c833a872450f9222a8ea1705d375aL9-R9) removing the previous logic that used environment variables to determine the domain.