### PR TITLE
feat: Remove unused social media icons from Introduction component

### DIFF
--- a/frontend/app/components/Home/Introduction.tsx
+++ b/frontend/app/components/Home/Introduction.tsx
@@ -2,7 +2,7 @@
 
 /* eslint-disable react/no-unescaped-entities */
 import React from "react";
-import { FaGithub, FaLinkedin, FaCode, FaTerminal, FaFacebook, FaInstagram, FaEnvelope, FaTwitter, FaYoutube } from 'react-icons/fa';
+import { FaGithub, FaLinkedin, FaCode, FaTerminal, FaEnvelope } from 'react-icons/fa';
 
 const Introduction: React.FC = () => {
   return (


### PR DESCRIPTION
This pull request makes a minor update to the `Introduction` component by removing unused social media icon imports, streamlining the code.