### PR TITLE
feat: Update robots and sitemap configurations with new domain and im…

### DIFF
--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,19 +1,16 @@
 import { MetadataRoute } from 'next';
 
-/**
- * Generate robots.txt file
- * @returns Robots.txt configuration
- */
 export default function robots(): MetadataRoute.Robots {
-  // Get domain dynamically from environment or default to localhost
-  const baseUrl = 'http://ankan.site';
+  const baseUrl = 'https://ankan.in'; // Replace with your actual domain
 
   return {
-    rules: {
-      userAgent: '*',
-      allow: '/',
-      disallow: ['/api/'],
-    },
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/admin/'],
+      },
+    ],
     sitemap: `${baseUrl}/sitemap.xml`,
   };
 }

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,36 +1,32 @@
 import { MetadataRoute } from 'next';
 
-/**
- * Generate a sitemap for the website
- * @returns Sitemap configuration
- */
 export default function sitemap(): MetadataRoute.Sitemap {
-  // Get domain dynamically from environment or default to localhost
-  const baseUrl = 'http://ankan.site';
+  const baseUrl = 'https://ankan.in';
 
-  // Current date
-  const currentDate = new Date().toISOString();
-
-  // Define routes
-  // You can add more routes as needed
   return [
     {
-      url: `${baseUrl}`,
-      lastModified: currentDate,
-      changeFrequency: 'weekly' as const,
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
       priority: 1.0,
     },
     {
       url: `${baseUrl}/about`,
-      lastModified: currentDate,
-      changeFrequency: 'monthly' as const,
-      priority: 0.8,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/projects`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.9,
     },
     {
       url: `${baseUrl}/contact`,
-      lastModified: currentDate,
-      changeFrequency: 'monthly' as const,
-      priority: 0.7,
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.8,
     },
   ];
 }


### PR DESCRIPTION
This pull request updates the site's SEO configuration by refining both the `robots.txt` and sitemap generation logic. The main changes include updating the domain, improving the disallow rules for crawlers, and expanding the sitemap with more accurate metadata and additional routes.

**SEO and Crawler Rules Updates:**

- Changed the domain in both `robots.ts` and `sitemap.ts` from `http://ankan.site` to `https://ankan.in` to reflect the correct production URL. [[1]](diffhunk://#diff-529628bc9eecdd7f290c32db24832aa4e64a6adab6dbd02286cd550a7241c1f8L3-R13) [[2]](diffhunk://#diff-6aba68df4b2f30b05f40df85caaca72e170c833a872450f9222a8ea1705d375aL3-R29)
- Updated the robots.txt rules to also disallow the `/admin/` path in addition to `/api/`, providing better protection for sensitive routes.

**Sitemap Improvements:**

- Added the `/projects` route to the sitemap, ensuring it is indexed by search engines.
- Adjusted `lastModified` to use the current date directly and updated `changeFrequency` and `priority` values for several routes to better reflect their update schedules and importance.…proved rules