### PR TITLE
feat: Update API server_name to include new domain

### DIFF
--- a/config/ankanweb.conf
+++ b/config/ankanweb.conf
@@ -4,7 +4,7 @@ upstream PortfolioBackendServer{
 
 # API subdomain configuration
 server {
-    server_name api.ankanweb.site;
+    server_name api.ankan.in api.ankan.site;
     
     # Global Configuration
     client_max_body_size 999G;


### PR DESCRIPTION
This pull request updates the API server configuration to support additional domains. The `server_name` directive now includes both `api.ankan.in` and `api.ankan.site`, in addition to the original domain.

- Configuration update:
  * [`config/ankanweb.conf`](diffhunk://#diff-9bd51422cb9056c5d7cda531a62abd1abd357b08903cd8d84db5c75bfee17e4fL7-R7): Expanded the `server_name` directive for the API server to include `api.ankan.in` and `api.ankan.site`, allowing the server to respond to requests on these domains.