### PR TITLE
fix: Remove deprecated domain from API server_name configuration

### DIFF
--- a/config/ankanweb.conf
+++ b/config/ankanweb.conf
@@ -4,7 +4,7 @@ upstream PortfolioBackendServer{
 
 # API subdomain configuration
 server {
-    server_name api.ankan.in api.ankan.site;
+    server_name api.ankan.in;
     
     # Global Configuration
     client_max_body_size 999G;


### PR DESCRIPTION
This pull request makes a minor update to the API subdomain configuration by removing `api.ankan.site` from the list of server names in the `config/ankanweb.conf` file. This change ensures that only `api.ankan.in` is recognized as the server name for this configuration.