### PR TITLE
fix: Update server header to include full name in SSL configuration

### DIFF
--- a/config/ankanweb.conf
+++ b/config/ankanweb.conf
@@ -14,7 +14,7 @@ server {
     
     # SSL Configuration & Headers Security
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
-    add_header server "AnkanWeb-API";
+    add_header server "AnkanWeb-API-Server";
 
     # Forward all requests to the backend node server
     location / {


### PR DESCRIPTION
This pull request includes a minor update to the HTTP response headers for the web server configuration. The change updates the value of the `server` header to provide a more specific identifier.

* Web server response header update:
  * In `config/ankanweb.conf`, the value of the `server` header was changed from `"AnkanWeb-API"` to `"AnkanWeb-API-Server"` to clarify the server identity.