### PR TITLE
feat: add reload command and update exit message in TerminalPortfolio

### DIFF
--- a/frontend/app/components/Terminal/TerminalPortfolio.tsx
+++ b/frontend/app/components/Terminal/TerminalPortfolio.tsx
@@ -161,7 +161,16 @@ const TerminalPortfolio: React.FC = () => {
     },
     exit: () => {
       writeLine('\r\n\x1b[1;33mThanks for visiting! Goodbye! 👋\x1b[0m');
-      writeLine('\x1b[90m(Refresh the page to start a new session)\x1b[0m');
+      writeLine('\x1b[90mReloading session...\x1b[0m\r\n');
+      setTimeout(() => {
+        window.location.reload();
+      }, 1500);
+    },
+    reload: () => {
+      writeLine('\r\n\x1b[1;36mReloading terminal session...\x1b[0m\r\n');
+      setTimeout(() => {
+        window.location.reload();
+      }, 1000);
     },
     sudo: () => {
       writeLine('\r\n\x1b[1;31m[sudo] password for ankan: \x1b[0m');
@@ -336,8 +345,9 @@ const TerminalPortfolio: React.FC = () => {
     writeLine('\x1b[1;36m║\x1b[0m                                                                       \x1b[1;36m║\x1b[0m');
     writeLine('\x1b[1;36m║\x1b[0m  \x1b[1;33m⚙️  SYSTEM COMMANDS:\x1b[0m                                                \x1b[1;36m║\x1b[0m');
     writeLine('\x1b[1;36m║\x1b[0m    \x1b[1;32mclear\x1b[0m          Clear terminal screen                             \x1b[1;36m║\x1b[0m');
+    writeLine('\x1b[1;36m║\x1b[0m    \x1b[1;32mreload\x1b[0m         Reload terminal session                           \x1b[1;36m║\x1b[0m');
     writeLine('\x1b[1;36m║\x1b[0m    \x1b[1;32mhelp\x1b[0m           Show this help message                            \x1b[1;36m║\x1b[0m');
-    writeLine('\x1b[1;36m║\x1b[0m    \x1b[1;32mexit\x1b[0m           Exit terminal session                             \x1b[1;36m║\x1b[0m');
+    writeLine('\x1b[1;36m║\x1b[0m    \x1b[1;32mexit\x1b[0m           Exit and reload session                           \x1b[1;36m║\x1b[0m');
     writeLine('\x1b[1;36m║\x1b[0m                                                                       \x1b[1;36m║\x1b[0m');
     writeLine('\x1b[1;36m╚═══════════════════════════════════════════════════════════════════════╝\x1b[0m');
     writeLine('\r\n\x1b[90mTip: Use ↑↓ arrows for history, Tab for autocomplete, Ctrl+L to clear.\x1b[0m\r\n');


### PR DESCRIPTION
This pull request enhances the terminal experience by introducing a new `reload` command and updating the behavior and messaging for the `exit` command in the `TerminalPortfolio` component. The changes improve session management and provide clearer instructions to users.

**Terminal command enhancements:**

* Added a new `reload` command that reloads the terminal session with a user-friendly message and a short delay before refreshing the page.
* Updated the `exit` command to now display a "Reloading session..." message and automatically reload the page after a brief pause, instead of instructing users to manually refresh.

**Help menu updates:**

* Updated the help output to include the new `reload` command and clarified the description for the `exit` command to indicate it now exits and reloads the session.