### PR TITLE
Remove edge runtime declaration from GitHub API route

### DIFF
--- a/frontend/app/api/github/route.ts
+++ b/frontend/app/api/github/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
 import { fetchGitHubStats } from "../../lib/github";
 
-export const runtime = "edge";
-
 export async function GET() {
   try {
     const data = await fetchGitHubStats();


### PR DESCRIPTION
This pull request makes a small change to the `frontend/app/api/github/route.ts` file by removing the `runtime = "edge"` export. This likely affects how the API route is deployed or executed within the Next.js framework.