### PR TITLE
Update sitemap to use consistent lastModified date and adjust changeF…

### DIFF
--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -2,29 +2,36 @@ import { MetadataRoute } from 'next';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = 'https://ankan.in';
+  const currentDate = new Date().toISOString();
 
   return [
     {
       url: baseUrl,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
+      lastModified: currentDate,
+      changeFrequency: 'weekly',
       priority: 1.0,
     },
     {
       url: `${baseUrl}/about`,
-      lastModified: new Date(),
+      lastModified: currentDate,
       changeFrequency: 'monthly',
       priority: 0.9,
     },
     {
       url: `${baseUrl}/projects`,
-      lastModified: new Date(),
+      lastModified: currentDate,
       changeFrequency: 'weekly',
-      priority: 0.9,
+      priority: 0.95,
+    },
+    {
+      url: `${baseUrl}/skills`,
+      lastModified: currentDate,
+      changeFrequency: 'monthly',
+      priority: 0.85,
     },
     {
       url: `${baseUrl}/contact`,
-      lastModified: new Date(),
+      lastModified: currentDate,
       changeFrequency: 'yearly',
       priority: 0.8,
     },


### PR DESCRIPTION
This pull request updates the sitemap generation logic to improve consistency and ensure all URLs have up-to-date metadata. The changes include using a single ISO-formatted date for all `lastModified` fields, adjusting change frequencies and priorities, and adding a new page to the sitemap.

Sitemap improvements:

* All `lastModified` fields now use a single ISO-formatted timestamp (`currentDate`) for consistency.
* The change frequency for the homepage (`/`) is set to `weekly` instead of `monthly`.
* The priority for the `/projects` page is increased from 0.9 to 0.95.
* A new entry for the `/skills` page is added to the sitemap with appropriate metadata.…requency for root URL