### PR TITLE
Refactor sitemap generation to include blog sitemap parsing and impro…

### DIFF
--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,39 +1,77 @@
 import { MetadataRoute } from 'next';
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://ankan.in';
-  const currentDate = new Date().toISOString();
+const baseUrl = 'https://ankan.in';
+const blogSitemapUrl = 'https://blog.ankan.in/sitemap.xml';
+const VALID_FREQUENCIES = new Set([
+  'always',
+  'hourly',
+  'daily',
+  'weekly',
+  'monthly',
+  'yearly',
+  'never',
+]);
 
-  return [
-    {
-      url: baseUrl,
-      lastModified: currentDate,
-      changeFrequency: 'weekly',
-      priority: 1.0,
-    },
-    {
-      url: `${baseUrl}/about`,
-      lastModified: currentDate,
-      changeFrequency: 'monthly',
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/projects`,
-      lastModified: currentDate,
-      changeFrequency: 'weekly',
-      priority: 0.95,
-    },
-    {
-      url: `${baseUrl}/skills`,
-      lastModified: currentDate,
-      changeFrequency: 'monthly',
-      priority: 0.85,
-    },
-    {
-      url: `${baseUrl}/contact`,
-      lastModified: currentDate,
-      changeFrequency: 'yearly',
-      priority: 0.8,
-    },
-  ];
+const staticRoutes: Array<{
+  path: string;
+  changeFrequency: NonNullable<MetadataRoute.Sitemap[number]['changeFrequency']>;
+  priority: number;
+}> = [
+  { path: '', changeFrequency: 'weekly', priority: 1.0 },
+  { path: '/about', changeFrequency: 'monthly', priority: 0.9 },
+  { path: '/projects', changeFrequency: 'weekly', priority: 0.95 },
+  { path: '/skills', changeFrequency: 'monthly', priority: 0.85 },
+  { path: '/contact', changeFrequency: 'yearly', priority: 0.8 },
+];
+
+// Hashnode serves a plain <urlset> (not a sitemap index), so a regex scan is
+// enough — pulled out as a pure function so it can be exercised without a fetch.
+export function parseBlogSitemap(xml: string): MetadataRoute.Sitemap {
+  const entries: MetadataRoute.Sitemap = [];
+
+  for (const match of xml.matchAll(/<url>([\s\S]*?)<\/url>/g)) {
+    const block = match[1];
+    const loc = block.match(/<loc>(.*?)<\/loc>/)?.[1];
+    if (!loc) continue;
+
+    const lastmod = block.match(/<lastmod>(.*?)<\/lastmod>/)?.[1];
+    const changefreq = block.match(/<changefreq>(.*?)<\/changefreq>/)?.[1];
+    const priority = block.match(/<priority>(.*?)<\/priority>/)?.[1];
+
+    entries.push({
+      url: loc,
+      lastModified: lastmod ? new Date(lastmod) : new Date(),
+      changeFrequency: VALID_FREQUENCIES.has(changefreq ?? '')
+        ? (changefreq as MetadataRoute.Sitemap[number]['changeFrequency'])
+        : 'daily',
+      priority: priority ? parseFloat(priority) : 0.7,
+    });
+  }
+
+  return entries;
+}
+
+async function getBlogSitemap(): Promise<MetadataRoute.Sitemap> {
+  try {
+    const res = await fetch(blogSitemapUrl, { cache: 'no-store' });
+    if (!res.ok) return [];
+    return parseBlogSitemap(await res.text());
+  } catch {
+    return [];
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const currentDate = new Date();
+
+  const pages: MetadataRoute.Sitemap = staticRoutes.map((route) => ({
+    url: `${baseUrl}${route.path}`,
+    lastModified: currentDate,
+    changeFrequency: route.changeFrequency,
+    priority: route.priority,
+  }));
+
+  const blogPages = await getBlogSitemap();
+
+  return [...pages, ...blogPages];
 }


### PR DESCRIPTION
This pull request refactors and enhances the sitemap generation in `frontend/app/sitemap.ts`. The main improvement is that the sitemap now dynamically fetches and parses blog URLs from an external blog sitemap, in addition to statically defined routes. The code is also restructured for better maintainability and extensibility.

**Sitemap generation improvements:**

* Refactored static routes into a `staticRoutes` array for easier management and mapping.
* Added logic to fetch and parse the external blog sitemap (`https://blog.ankan.in/sitemap.xml`) and merge its entries with the main sitemap.
* Introduced the `parseBlogSitemap` function to extract URLs and metadata from the blog sitemap XML using regex, with validation for `changeFrequency` values.

**Code structure and maintainability:**

* Changed the sitemap export to an async function to support fetching blog URLs at build time.
* Improved error handling for blog sitemap fetching and parsing, defaulting gracefully on failure.…ve change frequency handling